### PR TITLE
Standardize comparators to use 'equals' or 'does not equal'

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ config = [
     conditions: [
       %{column: "title", comparator: "contains", value: "Buy", type: "text"},
       %{column: "title", comparator: "does not contain", value: "Milk", type: "text"},
-      %{column: "flag", comparator: "is", value: "false", type: "boolean"}
+      %{column: "flag", comparator: "equals", value: "false", type: "boolean"}
     ],
     sub_filters: [%{
       filter: %{
@@ -96,17 +96,17 @@ The [documentation](http://rcdilorenzo.github.io/filtrex) is filled with valuabl
 The following condition types and comparators are supported.
 
 * [Filtrex.Condition.Boolean](http://rcdilorenzo.github.io/filtrex/Filtrex.Condition.Boolean.html)
-    * is, is not
+    * equals, does not equal
 * [Filtrex.Condition.Text](http://rcdilorenzo.github.io/filtrex/Filtrex.Condition.Text.html)
-    * is, is not, equals, does not equal, contains, does not contain
+    * equals, does not equal, contains, does not contain
 * [Filtrex.Condition.Date](http://rcdilorenzo.github.io/filtrex/Filtrex.Condition.Date.html)
-    * after, on or after, before, on or before, between, not between, equals, does not equal, is, is not
+    * after, on or after, before, on or before, between, not between, equals, does not equal
     * options: format (default: `{YYYY}-{0M}-{0D}`)
 * [Filtrex.Condition.DateTime](http://rcdilorenzo.github.io/filtrex/Filtrex.Condition.DateTime.html)
-    * after, on or after, before, on or before, equals, does not equal, is, is not
+    * after, on or after, before, on or before, equals, does not equal
     * options: format (default: `{ISOz}`)
 * [Filtrex.Condition.Number](http://rcdilorenzo.github.io/filtrex/Filtrex.Condition.Number.html)
-    * is, is not, greater than, less than or, greater than or, less than
+    * equals, does not equal, greater than, less than or, greater than or, less than
     * options: allow_decimal (default: false), allowed_values (default: nil)
 
 ## Installation (when 0.3.0 is available)

--- a/lib/filtrex/conditions/boolean.ex
+++ b/lib/filtrex/conditions/boolean.ex
@@ -3,12 +3,12 @@ defmodule Filtrex.Condition.Boolean do
 
   @type t :: Filtrex.Condition.Boolean
   @moduledoc """
-  `Filtrex.Condition.Boolean` is a specific ondition type for handling boolean flags. It allows an empty string for false value as well as string representations "true" and "false". Its comparators only consist of "is" or "is not". There are no configuration options for the boolean condition.
+  `Filtrex.Condition.Boolean` is a specific ondition type for handling boolean flags. It allows an empty string for false value as well as string representations "true" and "false". Its comparators only consist of "equals" or "does not equal". There are no configuration options for the boolean condition.
   """
 
   def type, do: :boolean
 
-  def comparators, do: ["is", "is not"]
+  def comparators, do: ["equals", "does not equal"]
 
   def parse(_config, %{column: column, comparator: comparator, value: value, inverse: inverse}) do
     parsed_comparator = validate_in(comparator, comparators)
@@ -38,7 +38,7 @@ defmodule Filtrex.Condition.Boolean do
   defp validate_value(_), do: nil
 
   defimpl Filtrex.Encoder do
-    encoder "is", "is not", "column = ?"
-    encoder "is not", "is", "column != ?"
+    encoder "equals", "does not equal", "column = ?"
+    encoder "does not equal", "equals", "column != ?"
   end
 end

--- a/lib/filtrex/conditions/date.ex
+++ b/lib/filtrex/conditions/date.ex
@@ -1,7 +1,7 @@
 defmodule Filtrex.Condition.Date do
   use Filtrex.Condition
   use Timex
-  @string_date_comparators ["equals", "does not equal", "is", "is not", "after", "on or after", "before", "on or before"]
+  @string_date_comparators ["equals", "does not equal", "after", "on or after", "before", "on or before"]
   @start_end_comparators ["between", "not between"]
   @comparators @string_date_comparators ++ @start_end_comparators
   @shifts [:days, :weeks, :months, :years]
@@ -26,7 +26,7 @@ defmodule Filtrex.Condition.Date do
   | inverse    | boolean | See `Filtrex.Condition.Text`              |
   | column     | string  | any allowed keys from passed `config`     |
   | comparator | string  | after, on or after, before, on or before,\|
-  |            |         | is, is not, equals, does not equal        |
+  |            |         | equals, does not equal                    |
   | value      | string  | "YYYY-MM-DD"                              |
   | type       | string  | "date"                                    |
 
@@ -88,9 +88,6 @@ defmodule Filtrex.Condition.Date do
 
     encoder "equals", "does not equal", "column = ?", &default/1
     encoder "does not equal", "equals", "column != ?", &default/1
-
-    encoder "is", "is not", "column = ?", &default/1
-    encoder "is not", "is", "column != ?", &default/1
 
     defp default(timex_date) do
       {:ok, date} = Timex.format(timex_date, @format)

--- a/lib/filtrex/conditions/datetime.ex
+++ b/lib/filtrex/conditions/datetime.ex
@@ -3,7 +3,7 @@ defmodule Filtrex.Condition.DateTime do
   use Timex
 
   @format "{ISOz}"
-  @comparators ["equals", "does not equal", "is", "is not", "after", "on or after", "before", "on or before"]
+  @comparators ["equals", "does not equal", "after", "on or after", "before", "on or before"]
 
   @moduledoc """
   `Filtrex.Condition.DateTime` is a specific condition type for handling datetime filters with various comparisons.
@@ -24,7 +24,7 @@ defmodule Filtrex.Condition.DateTime do
   | inverse    | boolean | See `Filtrex.Condition.Text`              |
   | column     | string  | any allowed keys from passed `config`     |
   | comparator | string  | after, on or after, before, on or before,\|
-  |            |         | is, is not, equals, does not equal        |
+  |            |         | equals, does not equal                    |
   | value      | string  | "YYYY-MM-DD'T'HH:MM:ss.SSS'Z'" ({ISOz})   |
   | type       | string  | "datetime"                                |
   """
@@ -57,9 +57,6 @@ defmodule Filtrex.Condition.DateTime do
 
     encoder "equals", "does not equal", "column = ?", &default/1
     encoder "does not equal", "equals", "column != ?", &default/1
-
-    encoder "is", "is not", "column = ?", &default/1
-    encoder "is not", "is", "column != ?", &default/1
 
     defp default(timex_date) do
       {:ok, format} = Timex.format(timex_date, "{ISOdate} {ISOtime}")

--- a/lib/filtrex/conditions/number.ex
+++ b/lib/filtrex/conditions/number.ex
@@ -7,7 +7,6 @@ defmodule Filtrex.Condition.Number do
   integer and decimal filters with various configuration options.
 
   Comparators:
-    is, is not,
     greater than, less than or,
     greater than or, less than
 
@@ -22,7 +21,7 @@ defmodule Filtrex.Condition.Number do
   def type, do: :number
 
   def comparators, do: [
-    "is", "is not",
+    "equals", "does not equal",
     "greater than", "less than or",
     "greater than or", "less than"
   ]
@@ -94,8 +93,8 @@ defmodule Filtrex.Condition.Number do
   defp parse_value(_, value), do: {:error, parse_value_type_error(value, type)}
 
   defimpl Filtrex.Encoder do
-    encoder "is", "is not", "column = ?"
-    encoder "is not", "is", "column != ?"
+    encoder "equals", "does not equal", "column = ?"
+    encoder "does not equal", "equals", "column != ?"
     encoder "greater than", "less than or", "column > ?"
     encoder "less than or", "greater than", "column <= ?"
     encoder "less than", "greater than or", "column < ?"

--- a/lib/filtrex/conditions/text.ex
+++ b/lib/filtrex/conditions/text.ex
@@ -1,6 +1,6 @@
 defmodule Filtrex.Condition.Text do
   use Filtrex.Condition
-  @comparators ["equals", "does not equal", "is", "is not", "contains", "does not contain"]
+  @comparators ["equals", "does not equal", "contains", "does not contain"]
 
   @type t :: Filtrex.Condition.Text.t
   @moduledoc """
@@ -11,7 +11,7 @@ defmodule Filtrex.Condition.Text do
   %{
     inverse: boolean,
     column: string,
-    comparator: string,  # equals, is, is not, contains, does not contain
+    comparator: string,  # equals, does not equal, contains, does not contain
     value: string,
     type: "text"
   }
@@ -46,9 +46,6 @@ defmodule Filtrex.Condition.Text do
   end
 
   defimpl Filtrex.Encoder do
-    encoder "is", "is not", "column = ?"
-    encoder "is not", "is", "column != ?"
-
     encoder "equals", "does not equal", "column = ?"
     encoder "does not equal", "equals", "column != ?"
 

--- a/lib/filtrex/encoder.ex
+++ b/lib/filtrex/encoder.ex
@@ -7,7 +7,7 @@ defprotocol Filtrex.Encoder do
   Example:
   ```
   defimpl Filtrex.Encoder, for: Filtrex.Condition.Text do
-    def encode(%Filtrex.Condition.Text{column: column, comparator: "is", value: value}) do
+    def encode(%Filtrex.Condition.Text{column: column, comparator: "equals", value: value}) do
       %Filtrex.Fragment{expression: "\#\{column\} = ?", values: [value]}
     end
   end

--- a/lib/filtrex/utils/encoder.ex
+++ b/lib/filtrex/utils/encoder.ex
@@ -8,7 +8,7 @@ defmodule Filtrex.Utils.Encoder do
 
   Example:
   ```
-  encoder "is", "is not", "column = ?", &(&1)
+  encoder "equals", "does not equal", "column = ?", &(&1)
   ```
 
   In this example, a comparator and its reverse are passed in followed

--- a/test/ast_test.exs
+++ b/test/ast_test.exs
@@ -4,7 +4,7 @@ defmodule FiltrexASTTest do
 
   @filter %Filtrex{type: "any", conditions: [
     %Filtrex.Condition.Text{column: "title", comparator: "contains", value: "created"},
-    %Filtrex.Condition.Text{column: "title", comparator: "is not", value: "Chris McCord"}
+    %Filtrex.Condition.Text{column: "title", comparator: "does not equal", value: "Chris McCord"}
   ], sub_filters: [
     %Filtrex{type: "all", conditions: [
       %Filtrex.Condition.Date{column: "date_column", comparator: "after", value: Timex.date({2016, 5, 1})},

--- a/test/conditions/boolean_test.exs
+++ b/test/conditions/boolean_test.exs
@@ -25,18 +25,18 @@ defmodule FiltrexConditionBooleanTest do
   end
 
   test "encoding true value" do
-    assert Filtrex.Encoder.encode(condition(true, "is")) ==
+    assert Filtrex.Encoder.encode(condition(true, "equals")) ==
       %Filtrex.Fragment{expression: "flag = ?", values: [true]}
 
-    assert Filtrex.Encoder.encode(condition(true, "is not")) ==
+    assert Filtrex.Encoder.encode(condition(true, "does not equal")) ==
       %Filtrex.Fragment{expression: "flag != ?", values: [true]}
   end
 
   test "encoding false value" do
-    assert Filtrex.Encoder.encode(condition(false, "is")) ==
+    assert Filtrex.Encoder.encode(condition(false, "equals")) ==
       %Filtrex.Fragment{expression: "flag = ?", values: [false]}
 
-    assert Filtrex.Encoder.encode(condition(false, "is not")) ==
+    assert Filtrex.Encoder.encode(condition(false, "does not equal")) ==
       %Filtrex.Fragment{expression: "flag != ?", values: [false]}
   end
 
@@ -44,10 +44,10 @@ defmodule FiltrexConditionBooleanTest do
     %{inverse: false,
       column: @column,
       value: value,
-      comparator: "is"}
+      comparator: "equals"}
   end
 
-  defp condition(value, comparator \\ "is") do
+  defp condition(value, comparator \\ "equals") do
     %Boolean{type: :boolean, column: @column,
       inverse: false, comparator: comparator, value: value}
   end

--- a/test/conditions/date_test.exs
+++ b/test/conditions/date_test.exs
@@ -50,12 +50,12 @@ defmodule FiltrexConditionDateTest do
                     inverse: false, type: :date, value: Timex.date({2016, 12, 29})}}
   end
 
-  test "'is' comparator" do
+  test "'equals' comparator" do
     assert Date.parse(@config, %{
       inverse: false,
       column: @column,
       value: "2016-05-18",
-      comparator: "is"
+      comparator: "equals"
     }) |> elem(0) == :ok
   end
 
@@ -76,9 +76,6 @@ defmodule FiltrexConditionDateTest do
 
     assert encode(Date, @column, "2016-03-01", "does not equal") ==
       {"date_column != ?", ["2016-03-01"]}
-
-    assert encode(Date, @column, "2016-02-10", "is") ==
-      {"date_column = ?", ["2016-02-10"]}
   end
 
   defp encode(module, column, value, comparator) do

--- a/test/conditions/datetime_test.exs
+++ b/test/conditions/datetime_test.exs
@@ -50,9 +50,6 @@ defmodule FiltrexConditionDateTimeTest do
 
     assert encode(DateTime, @column, @default, "equals")         == {"datetime_column = ?", [@default_converted]}
     assert encode(DateTime, @column, @default, "does not equal") == {"datetime_column != ?", [@default_converted]}
-
-    assert encode(DateTime, @column, @default, "is")         == {"datetime_column = ?", [@default_converted]}
-    assert encode(DateTime, @column, @default, "is not")     == {"datetime_column != ?", [@default_converted]}
   end
 
   defp encode(module, column, value, comparator) do

--- a/test/conditions/number_test.exs
+++ b/test/conditions/number_test.exs
@@ -7,46 +7,46 @@ defmodule FiltrexConditionNumberTest do
             options: %{allowed_values: 1..100, allow_decimal: true}}
 
   test "parsing integer successfully" do
-    assert Number.parse(@config, params("is", "10")) ==
-      {:ok, condition("is", 10)}
+    assert Number.parse(@config, params("equals", "10")) ==
+      {:ok, condition("equals", 10)}
 
-    assert Number.parse(@config, params("is", "1")) ==
-      {:ok, condition("is", 1)}
+    assert Number.parse(@config, params("equals", "1")) ==
+      {:ok, condition("equals", 1)}
 
-    assert Number.parse(@config, params("is", 5)) ==
-      {:ok, condition("is", 5)}
+    assert Number.parse(@config, params("equals", 5)) ==
+      {:ok, condition("equals", 5)}
   end
 
   test "parsing float successfully" do
-    assert Number.parse(@config, params("is", "3.5")) ==
-      {:ok, condition("is", 3.5)}
+    assert Number.parse(@config, params("equals", "3.5")) ==
+      {:ok, condition("equals", 3.5)}
   end
 
   test "parsing number errors" do
-    assert Number.parse(@config, params("is", "blah")) ==
+    assert Number.parse(@config, params("equals", "blah")) ==
       {:error, "Invalid number value for blah"}
 
-    assert Number.parse(@config, params("is", "")) ==
+    assert Number.parse(@config, params("equals", "")) ==
       {:error, "Invalid number value for "}
 
-    assert Number.parse(@config, params("is", nil)) ==
+    assert Number.parse(@config, params("equals", nil)) ==
       {:error, "Invalid number value for 'nil'"}
 
 
-    assert Number.parse(put_in(@config.options[:allow_decimal], false), params("is", "10.5")) ==
+    assert Number.parse(put_in(@config.options[:allow_decimal], false), params("equals", "10.5")) ==
       {:error, "Invalid number value for 10.5"}
   end
 
   test "validating range of allowed integer values" do
-    assert Number.parse(@config, params("is", "101")) ==
+    assert Number.parse(@config, params("equals", "101")) ==
       {:error, "Provided number value not allowed"}
 
-    assert Number.parse(@config, params("is", "-1")) ==
+    assert Number.parse(@config, params("equals", "-1")) ==
       {:error, "Provided number value not allowed"}
   end
 
   test "validating range of allowed float values" do
-    assert Number.parse(@config, params("is", "100.5")) ==
+    assert Number.parse(@config, params("equals", "100.5")) ==
       {:error, "Provided number value not allowed"}
   end
 

--- a/test/conditions/text_test.exs
+++ b/test/conditions/text_test.exs
@@ -25,7 +25,7 @@ defmodule FiltrexConditionTextTest do
     assert encoded.values == ["Buy Milk"]
     assert encoded.expression == "title = ?"
 
-    {:ok, condition} = Text.parse(@config, %{inverse: false, column: "title", value: "Buy Milk", comparator: "is not"})
+    {:ok, condition} = Text.parse(@config, %{inverse: false, column: "title", value: "Buy Milk", comparator: "does not equal"})
     encoded = Filtrex.Encoder.encode(condition)
     assert encoded.expression == "title != ?"
 

--- a/test/filtrex_test.exs
+++ b/test/filtrex_test.exs
@@ -30,7 +30,7 @@ defmodule FiltrexTest do
     {:ok, filter} =  Filtrex.parse(@config, %{
       filter: %{type: "all", conditions: [
         %{type: "text", column: "title", comparator: "contains", value: "earth"},
-        %{type: "text", column: "title", comparator: "is not", value: "The earth was without form and void;"}
+        %{type: "text", column: "title", comparator: "does not equal", value: "The earth was without form and void;"}
       ]}
     })
     assert_count filter, 1
@@ -50,7 +50,7 @@ defmodule FiltrexTest do
     {:ok, filter} =  Filtrex.parse(@config, %{
       filter: %{type: "none", conditions: [
         %{type: "text", column: "title", comparator: "contains", value: "earth"},
-        %{type: "text", column: "title", comparator: "is", value: "Chris McCord"}
+        %{type: "text", column: "title", comparator: "equals", value: "Chris McCord"}
       ]}
     })
     assert_count filter, 4
@@ -62,7 +62,7 @@ defmodule FiltrexTest do
         type: "any",
         conditions: [
           %{type: "text", column: "title", comparator: "contains", value: "earth"},
-          %{type: "text", column: "title", comparator: "is", value: "Chris McCord"}
+          %{type: "text", column: "title", comparator: "equals", value: "Chris McCord"}
         ],
         sub_filters: [%{filter: %{type: "all", conditions: [
           %{type: "date", column: "date_column", comparator: "after", value: "2016-03-26"},
@@ -114,7 +114,7 @@ defmodule FiltrexTest do
         %Filtrex.Condition.Boolean{
           type: :boolean,
           column: "flag",
-          comparator: "is",
+          comparator: "equals",
           value: false,
           inverse: false
         },


### PR DESCRIPTION
See #18 
