### PR TITLE
Add case insensitivity for LIKE queries

### DIFF
--- a/lib/filtrex/conditions/text.ex
+++ b/lib/filtrex/conditions/text.ex
@@ -49,7 +49,7 @@ defmodule Filtrex.Condition.Text do
     encoder "equals", "does not equal", "column = ?"
     encoder "does not equal", "equals", "column != ?"
 
-    encoder "contains", "does not contain", "column LIKE ?", &(["%#{&1}%"])
-    encoder "does not contain", "contains", "column NOT LIKE ?", &(["%#{&1}%"])
+    encoder "contains", "does not contain", "lower(column) LIKE lower(?)", &(["%#{&1}%"])
+    encoder "does not contain", "contains", "lower(column) NOT LIKE lower(?)", &(["%#{&1}%"])
   end
 end

--- a/test/ast_test.exs
+++ b/test/ast_test.exs
@@ -16,7 +16,7 @@ defmodule FiltrexASTTest do
     ast = Filtrex.AST.build_query(Filtrex.SampleModel, @filter)
     expression = Macro.to_string(quote do: unquote(ast))
     assert with_newline(expression) == """
-    Ecto.Query.where(Filtrex.SampleModel, [s], fragment("((title LIKE ?) OR (title != ?)) OR ((date_column > ?) AND (date_column < ?))", "%created%", "Chris McCord", "2016-05-01", "2017-01-01"))
+    Ecto.Query.where(Filtrex.SampleModel, [s], fragment("((lower(title) LIKE lower(?)) OR (title != ?)) OR ((date_column > ?) AND (date_column < ?))", "%created%", "Chris McCord", "2016-05-01", "2017-01-01"))
     """
   end
 

--- a/test/conditions/text_test.exs
+++ b/test/conditions/text_test.exs
@@ -31,11 +31,11 @@ defmodule FiltrexConditionTextTest do
 
     {:ok, condition} = Text.parse(@config, %{inverse: false, column: "title", value: "Buy Milk", comparator: "contains"})
     encoded = Filtrex.Encoder.encode(condition)
-    assert encoded.expression == "title LIKE ?"
+    assert encoded.expression == "lower(title) LIKE lower(?)"
 
     {:ok, condition} = Text.parse(@config, %{inverse: false, column: "title", value: "Buy Milk", comparator: "does not contain"})
     encoded = Filtrex.Encoder.encode(condition)
-    assert encoded.expression == "title NOT LIKE ?"
+    assert encoded.expression == "lower(title) NOT LIKE lower(?)"
     assert encoded.values == ["%Buy Milk%"]
   end
 end


### PR DESCRIPTION
Usually, you want your LIKE queries to be case insensitive. Even though it does incur a modest performance hit, it makes the LIKE query much more likely to return proper results.

For example, if you're searching for any records that include "Hello", it's nice to be able to type "Hello", and get results for "hello" as well.
