### PR TITLE
Fix warnings on Elixir 1.5+

### DIFF
--- a/lib/filtrex.ex
+++ b/lib/filtrex.ex
@@ -35,7 +35,7 @@ defmodule Filtrex do
   [%Filtrex.Type.Config{type: :text, keys: ~w(title comments)}]
   ```
   """
-  @spec parse([Filtrex.Type.Config.t], Map.t) :: {:error, string} | {:ok, Filtrex.t}
+  @spec parse([Filtrex.Type.Config.t], Map.t) :: {:error, String.t} | {:ok, Filtrex.t}
   def parse(configs, map) do
     with {:ok, sanitized} <- Filtrex.Params.sanitize(map, @whitelist),
          {:ok, valid_structured_map} <- validate_structure(sanitized),

--- a/lib/filtrex/condition.ex
+++ b/lib/filtrex/condition.ex
@@ -68,7 +68,7 @@ defmodule Filtrex.Condition do
 
   @doc "Parses a params key into the condition type, column, and comparator"
   def param_key_type(configs, key_with_comparator) do
-    result = Enum.find_value(condition_modules, fn (module) ->
+    result = Enum.find_value(condition_modules(), fn (module) ->
       Enum.find_value(module.comparators, fn (comparator) ->
         normalized = "_" <> String.replace(comparator, " ", "_")
         key = String.replace_trailing(key_with_comparator, normalized, "")
@@ -138,7 +138,7 @@ defmodule Filtrex.Condition do
   end
 
   defp condition_module(type) do
-    Enum.find(condition_modules, fn (module) ->
+    Enum.find(condition_modules(), fn (module) ->
       type == to_string(module.type)
     end)
   end

--- a/lib/filtrex/conditions/boolean.ex
+++ b/lib/filtrex/conditions/boolean.ex
@@ -11,10 +11,10 @@ defmodule Filtrex.Condition.Boolean do
   def comparators, do: ["equals", "does not equal"]
 
   def parse(_config, %{column: column, comparator: comparator, value: value, inverse: inverse}) do
-    parsed_comparator = validate_in(comparator, comparators)
+    parsed_comparator = validate_in(comparator, comparators())
 
     condition = %Condition.Boolean{
-      type: type,
+      type: type(),
       inverse: inverse,
       column: column,
       comparator: parsed_comparator,

--- a/lib/filtrex/conditions/date.ex
+++ b/lib/filtrex/conditions/date.ex
@@ -4,7 +4,6 @@ defmodule Filtrex.Condition.Date do
   @string_date_comparators ["equals", "does not equal", "after", "on or after", "before", "on or before"]
   @start_end_comparators ["between", "not between"]
   @comparators @string_date_comparators ++ @start_end_comparators
-  @shifts [:days, :weeks, :months, :years]
 
   @type t :: Filtrex.Condition.Date.t
   @moduledoc """

--- a/lib/filtrex/conditions/datetime.ex
+++ b/lib/filtrex/conditions/datetime.ex
@@ -34,9 +34,9 @@ defmodule Filtrex.Condition.DateTime do
   def comparators, do: @comparators
 
   def parse(config, %{column: column, comparator: comparator, value: value, inverse: inverse}) do
-    with {:ok, parsed_comparator} <- validate_comparator(type, comparator, @comparators),
+    with {:ok, parsed_comparator} <- validate_comparator(type(), comparator, @comparators),
          {:ok, parsed_value}      <- validate_value(config, value) do
-      {:ok, %__MODULE__{type: type, inverse: inverse,
+      {:ok, %__MODULE__{type: type(), inverse: inverse,
           column: column, comparator: parsed_comparator,
           value: parsed_value}}
     end
@@ -47,8 +47,6 @@ defmodule Filtrex.Condition.DateTime do
   end
 
   defimpl Filtrex.Encoder do
-    @format Filtrex.Validator.Date.format
-
     encoder "after", "before", "column > ?", &default/1
     encoder "before", "after", "column < ?", &default/1
 

--- a/lib/filtrex/conditions/number.ex
+++ b/lib/filtrex/conditions/number.ex
@@ -28,16 +28,16 @@ defmodule Filtrex.Condition.Number do
 
   def parse(config, %{column: column, comparator: comparator, value: value, inverse: inverse}) do
     result = with {:ok, parsed_value} <- parse_value(config.options, value),
-      do: %Condition.Number{type: type, inverse: inverse, value: parsed_value, column: column,
-        comparator: validate_in(comparator, comparators)}
+      do: %Condition.Number{type: type(), inverse: inverse, value: parsed_value, column: column,
+        comparator: validate_in(comparator, comparators())}
 
     case result do
       {:error, error} ->
         {:error, error}
       %Condition.Number{comparator: nil} ->
-        {:error, parse_error(column, :comparator, type)}
+        {:error, parse_error(column, :comparator, type())}
       %Condition.Number{value: nil} ->
-        {:error, parse_value_type_error(value, type)}
+        {:error, parse_value_type_error(value, type())}
       _ ->
         {:ok, result}
     end
@@ -46,14 +46,14 @@ defmodule Filtrex.Condition.Number do
   defp parse_value(options = %{allow_decimal: true}, string) when is_binary(string) do
     case Float.parse(string) do
       {float, ""} -> parse_value(options, float)
-      _           -> {:error, parse_value_type_error(string, type)}
+      _           -> {:error, parse_value_type_error(string, type())}
     end
   end
 
   defp parse_value(options, string) when is_binary(string) do
     case Integer.parse(string) do
       {integer, ""} -> parse_value(options, integer)
-      _             -> {:error, parse_value_type_error(string, type)}
+      _             -> {:error, parse_value_type_error(string, type())}
     end
   end
 
@@ -61,7 +61,7 @@ defmodule Filtrex.Condition.Number do
     allowed_values = options[:allowed_values]
     cond do
       options[:allow_decimal] == false ->
-        {:error, parse_value_type_error(float, type)}
+        {:error, parse_value_type_error(float, type())}
       allowed_values == nil ->
         {:ok, float}
       Range.range?(allowed_values) ->
@@ -82,7 +82,7 @@ defmodule Filtrex.Condition.Number do
     allowed_values = options[:allowed_values]
     cond do
       options[:allow_decimal] == false ->
-        {:error, parse_value_type_error(integer, type)}
+        {:error, parse_value_type_error(integer, type())}
       allowed_values == nil or integer in allowed_values ->
         {:ok, integer}
       not integer in allowed_values ->
@@ -90,7 +90,7 @@ defmodule Filtrex.Condition.Number do
     end
   end
 
-  defp parse_value(_, value), do: {:error, parse_value_type_error(value, type)}
+  defp parse_value(_, value), do: {:error, parse_value_type_error(value, type())}
 
   defimpl Filtrex.Encoder do
     encoder "equals", "does not equal", "column = ?"

--- a/lib/filtrex/validators/date.ex
+++ b/lib/filtrex/validators/date.ex
@@ -1,5 +1,4 @@
 defmodule Filtrex.Validator.Date do
-  @intervals ~w(days weeks months years)
   @format "{YYYY}-{0M}-{0D}"
   @moduledoc false
 

--- a/test/support/sample_model.ex
+++ b/test/support/sample_model.ex
@@ -9,7 +9,7 @@ defmodule Filtrex.SampleModel do
     field :rating,          :float
     field :comments
 
-    timestamps
+    timestamps()
   end
 
   def filtrex_config do


### PR DESCRIPTION
Filtrex has a lot of compile warnings about improper function calls
(function calls should no longer look like variables) and unused module
attributes.