### PR TITLE
Update Filtrex.query spec type to allow Queryable values

### DIFF
--- a/lib/filtrex.ex
+++ b/lib/filtrex.ex
@@ -98,7 +98,7 @@ defmodule Filtrex do
   Filtrex.query(query, filter, allow_empty: true)
   ```
   """
-  @spec query(Ecto.Query.t, Filtrex.t, Keyword.t) :: Ecto.Query.t
+  @spec query(Ecto.Queryable.t, Filtrex.t, Keyword.t) :: Ecto.Query.t
   def query(queryable, filter, opts \\ [allow_empty: true])
   def query(queryable, %Filtrex{empty: true}, opts) do
     if opts[:allow_empty] do


### PR DESCRIPTION
While the docs and var names for this function make it clear that the first argument can be any ecto module, the spec type requires a `Query.t`, instead of the more permissive `Queryable.t`. This can cause issues on projects using dialyzer for static analysis.