### PR TITLE
Added "is null" and "is not null" comparators for Datetimes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ The following condition types and comparators are supported.
     * after, on or after, before, on or before, between, not between, equals, does not equal
     * options: format (default: `{YYYY}-{0M}-{0D}`)
 * [Filtrex.Condition.DateTime](http://rcdilorenzo.github.io/filtrex/Filtrex.Condition.DateTime.html)
-    * after, on or after, before, on or before, equals, does not equal
+    * after, on or after, before, on or before, equals, does not equal, is null, is not null
     * options: format (default: `{ISOz}`)
 * [Filtrex.Condition.Number](http://rcdilorenzo.github.io/filtrex/Filtrex.Condition.Number.html)
     * equals, does not equal, greater than, less than or, greater than or, less than

--- a/lib/filtrex/conditions/datetime.ex
+++ b/lib/filtrex/conditions/datetime.ex
@@ -3,7 +3,16 @@ defmodule Filtrex.Condition.DateTime do
   use Timex
 
   @format "{ISO:Extended}"
-  @comparators ["equals", "does not equal", "after", "on or after", "before", "on or before"]
+  @comparators [
+    "equals",
+    "does not equal",
+    "after",
+    "on or after",
+    "before",
+    "on or before",
+    "is null",
+    "is not null"
+  ]
 
   @moduledoc """
   `Filtrex.Condition.DateTime` is a specific condition type for handling datetime filters with various comparisons.
@@ -24,7 +33,8 @@ defmodule Filtrex.Condition.DateTime do
   | inverse    | boolean | See `Filtrex.Condition.Text`              |
   | column     | string  | any allowed keys from passed `config`     |
   | comparator | string  | after, on or after, before, on or before,\|
-  |            |         | equals, does not equal                    |
+  |            |         | equals, does not equal, is null,          |
+  |            |         | is not null                               |
   | value      | string  | "YYYY-MM-DD'T'HH:MM:ss.SSS'Z'" ({ISOz})   |
   | type       | string  | "datetime"                                |
   """
@@ -35,30 +45,49 @@ defmodule Filtrex.Condition.DateTime do
 
   def parse(config, %{column: column, comparator: comparator, value: value, inverse: inverse}) do
     with {:ok, parsed_comparator} <- validate_comparator(type(), comparator, @comparators),
-         {:ok, parsed_value}      <- validate_value(config, value) do
-      {:ok, %__MODULE__{type: type(), inverse: inverse,
-          column: column, comparator: parsed_comparator,
-          value: parsed_value}}
+         {:ok, parsed_value} <- validate_value(config, comparator, value) do
+
+      {:ok,
+       %__MODULE__{
+         type: type(),
+         inverse: inverse,
+         column: column,
+         comparator: parsed_comparator,
+         value: parsed_value
+       }}
     end
   end
 
-  defp validate_value(config, value) do
+  defp validate_comparator(comparator) when comparator in @comparators, do: {:ok, comparator}
+  defp validate_comparator(comparator), do: {:error, parse_error(comparator, :comparator, :date)}
+
+  defp validate_value(config, comparator, value) when comparator in ["is null", "is not null"] do
+    # no need for validation since the comparison is to 'NULL'
+    {:ok, nil}
+  end
+
+  defp validate_value(config, comparator, value) do
     Timex.parse(value, config.options[:format] || @format)
   end
 
   defimpl Filtrex.Encoder do
-    encoder "after", "before", "column > ?", &default/1
-    encoder "before", "after", "column < ?", &default/1
+    encoder("after", "before", "column > ?", &default/1)
+    encoder("before", "after", "column < ?", &default/1)
 
-    encoder "on or after", "on or before", "column >= ?", &default/1
-    encoder "on or before", "on or after", "column <= ?", &default/1
+    encoder("on or after", "on or before", "column >= ?", &default/1)
+    encoder("on or before", "on or after", "column <= ?", &default/1)
 
-    encoder "equals", "does not equal", "column = ?", &default/1
-    encoder "does not equal", "equals", "column != ?", &default/1
+    encoder("equals", "does not equal", "column = ?", &default/1)
+    encoder("does not equal", "equals", "column != ?", &default/1)
+
+    encoder("is null", "is not null", "column is ?", &null_for_comparison/1)
+    encoder("is not null", "is null", "column is not ?", &null_for_comparison/1)
 
     defp default(timex_date) do
       {:ok, format} = Timex.format(timex_date, "{ISOdate} {ISOtime}")
       [format]
     end
+
+    defp null_for_comparison(_ignored_value), do: [nil]
   end
 end

--- a/test/conditions/datetime_test.exs
+++ b/test/conditions/datetime_test.exs
@@ -55,6 +55,9 @@ defmodule FiltrexConditionDateTimeTest do
 
     assert encode(DateTime, @column, @default, "equals")         == {"? = ?", [column_ref(:datetime_column), @default_converted]}
     assert encode(DateTime, @column, @default, "does not equal") == {"? != ?", [column_ref(:datetime_column), @default_converted]}
+
+    assert encode(DateTime, @column, @default, "is null")         == {"? is ?", [column_ref(:datetime_column), nil]}
+    assert encode(DateTime, @column, @default, "is not null") == {"? is not ?", [column_ref(:datetime_column), nil]}
   end
 
   defp encode(module, column, value, comparator) do


### PR DESCRIPTION
 They work a little bit different from other comparisons, since "HTML parameters don't usually work with a language-specific construct of nil". The passed in value for the filter is ignored and the comparison to nil/NULL is made instead. 
 
For example, if you are filtering by parameters, you could 'add my_column_is_null' to the query string without a value - any value specified will be ignored.

This addresses https://github.com/rcdilorenzo/filtrex/issues/62. It only adds the null comparators for DateTimes, however, it is straightforward to add them to other data types.