### PR TITLE
Remove Elixir 1.17 warnings for condition.ex

### DIFF
--- a/lib/filtrex/condition.ex
+++ b/lib/filtrex/condition.ex
@@ -69,11 +69,11 @@ defmodule Filtrex.Condition do
   @doc "Parses a params key into the condition type, column, and comparator"
   def param_key_type(configs, key_with_comparator) do
     result = Enum.find_value(condition_modules(), fn (module) ->
-      Enum.find_value(module.comparators, fn (comparator) ->
+      Enum.find_value(module.comparators(), fn (comparator) ->
         normalized = "_" <> String.replace(comparator, " ", "_")
         key = String.replace_trailing(key_with_comparator, normalized, "")
         config = Filtrex.Type.Config.config(configs, key)
-        if !is_nil(config) and key in config.keys and config.type == module.type do
+        if !is_nil(config) and key in config.keys and config.type == module.type() do
           {:ok, module, config, key, comparator}
         end
       end)


### PR DESCRIPTION
The new Elixir 1.17 is deprecating the call of a function like this for 0 arity functions:
```elixir
module.function
```

It's necessary to call them like this:
```elixir
module.function()
```