### PR TITLE
Fix compilation on 1.20, replacing mod.fun syntax

### DIFF
--- a/lib/filtrex/config.ex
+++ b/lib/filtrex/config.ex
@@ -61,11 +61,11 @@ defmodule Filtrex.Type.Config do
     end
   end
 
-  for module <- Filtrex.Condition.condition_modules do
+  for module <- Filtrex.Condition.condition_modules() do
     @doc "Generate a config struct for `#{to_string(module) |> String.slice(7..-1)}`"
-    defmacro unquote(module.type)(key_or_keys, opts \\ [])
-    defmacro unquote(module.type)(keys, opts) when is_list(keys) do
-      type = unquote(module.type)
+    defmacro unquote(module.type())(key_or_keys, opts \\ [])
+    defmacro unquote(module.type())(keys, opts) when is_list(keys) do
+      type = unquote(module.type())
       quote do
         var!(configs) = var!(configs) ++
           [%Filtrex.Type.Config{type: unquote(type),
@@ -74,8 +74,8 @@ defmodule Filtrex.Type.Config do
       end
     end
 
-    defmacro unquote(module.type)(key, opts) do
-      type = unquote(module.type)
+    defmacro unquote(module.type())(key, opts) do
+      type = unquote(module.type())
       quote do
         unquote(type)([to_string(unquote(key))], unquote(opts))
       end


### PR DESCRIPTION
On elixir 1.120-rc.2, the project does not compile due to the use of the `mod.fun` syntax (`mod.fun()` is expected):

```elixir
== Compilation error in file lib/filtrex/config.ex ==
** (BadMapError) expected a map, got:

    Filtrex.Condition.Text

    lib/filtrex/config.ex:66: anonymous fn/2 in :elixir_compiler_361.__MODULE__/1
    (elixir 1.20.0-rc.2) lib/enum.ex:2617: Enum."-reduce/3-lists^foldl/2-0-"/3
    lib/filtrex/config.ex:64: (module)
could not compile dependency :filtrex, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile filtrex --force", update it with "mix deps.update filtrex" or clean it with "mix deps.clean filtrex"
** (exit) shutdown: 1
    (mix 1.20.0-rc.2) lib/mix/tasks/compile.all.ex:79: Mix.Tasks.Compile.All.do_run/2
    (mix 1.20.0-rc.2) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.20.0-rc.2) lib/mix/tasks/compile.ex:145: Mix.Tasks.Compile.run/1
    (mix 1.20.0-rc.2) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.20.0-rc.2) lib/mix/tasks/deps.compile.ex:230: anonymous fn/2 in Mix.Tasks.Deps.Compile.do_mix/2
    (mix 1.20.0-rc.2) lib/mix/project.ex:557: Mix.Project.in_project/4
    (elixir 1.20.0-rc.2) lib/file.ex:2032: File.cd!/2
```

Cf [changelog](https://hexdocs.pm/elixir/main/changelog.html#2-potential-breaking-changes):

> `map.foo()` (accessing a map field with parens) and `mod.foo` (invoking a function without parens) will now raise instead of emitting runtime warnings, aligning themselves with the type system behaviour