### PR TITLE
Add Elixir 1.19+ compatibility (tested through 1.20-rc.3)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
             elixir-version: "1.15"
           - otp-version: "27.3"
             elixir-version: "1.17"
+          - otp-version: "27.3"
+            elixir-version: "1.19"
 
     services:
       postgres:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 27.3.3
-elixir 1.17.3
+elixir 1.19.5

--- a/lib/filtrex/condition.ex
+++ b/lib/filtrex/condition.ex
@@ -119,15 +119,12 @@ defmodule Filtrex.Condition do
     "Invalid #{to_string(filter_type)} value for #{column}"
   end
   def parse_value_type_error(column, filter_type) do
-    opts   = struct(Inspect.Opts, [])
-    iodata = Inspect.Algebra.to_doc(column, opts)
-      |> Inspect.Algebra.format(opts.width)
-      |> Enum.join
+    inspected = inspect(column)
 
-    if String.length(iodata) <= 15 do
-      parse_value_type_error("'#{iodata}'", filter_type)
+    if String.length(inspected) <= 15 do
+      parse_value_type_error("'#{inspected}'", filter_type)
     else
-      "'#{String.slice(iodata, 0..12)}...#{String.slice(iodata, -3..-1)}'"
+      "'#{String.slice(inspected, 0..12)}...#{String.slice(inspected, -3..-1//1)}'"
         |> parse_value_type_error(filter_type)
     end
   end


### PR DESCRIPTION
## Summary
- Fix `parse_value_type_error` to use `inspect/1` instead of `Inspect.Algebra` + `Enum.join` (broke in Elixir 1.19 where `Inspect.Algebra.format/2` returns a binary instead of an iolist)
- Fix `String.slice` ranges to use step syntax (`-3..-1//1`)
- Add Elixir 1.19/OTP 27 to CI matrix
- Update `.tool-versions` to Elixir 1.19.5

Supersedes #72 — all the `mod.fun()` fixes from that PR were already included in #75.

## Tested on
- Elixir 1.15 + OTP 26 (CI)
- Elixir 1.17 + OTP 27 (CI)
- Elixir 1.19 + OTP 27 (CI)
- Elixir 1.20-rc.3 + OTP 27 (local)

## Test plan
- [x] CI green on all 3 matrix entries
- [x] All 65 tests pass